### PR TITLE
Fix self-update procedure

### DIFF
--- a/patch.sh
+++ b/patch.sh
@@ -244,7 +244,9 @@ if [ ! -f "${DIRECTORY}/no-update-patcher" ];then
   if [ "$localhash" != "$latesthash" ] && [ ! -z "$latesthash" ] && [ ! -z "$localhash" ];then
     echo "TwistUP-UI is out of date. Downloading new version..."
     gio trash "$DIRECTORY"
+    cd "$HOME"
     git clone https://github.com/phoenixbyrd/TwistUP-UI "$DIRECTORY"
+    cd "$DIRECTORY"
   fi
 fi
 


### PR DESCRIPTION
Untested fix for the output you reported:
```
TwistUP-Lite is out of date. Downloading new version...
Cloning into '/home/pi/.local/share/Trash/files/TwistUP-OS.
```
I have no idea how this was not caught sooner! We definitely did test the self-updating feature at the time of development, so I have no idea why nobody noticed sooner.